### PR TITLE
Fix integrated server thread freeze on client second world load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ replay_*.log
 *.hprof
 *.jfr
 .vscode/settings.json
+.vscode/launch.json
 /decomp

--- a/src/main/java/magicjinn/theblockkeepsticking/util/Timer.java
+++ b/src/main/java/magicjinn/theblockkeepsticking/util/Timer.java
@@ -86,7 +86,7 @@ public class Timer implements ServerTickEvents.EndTick {
         ServerTickEvents.END_SERVER_TICK.register(INSTANCE);
 
         // Register server shutdown event to clear pending actions
-        ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
             INSTANCE.clearAllPendingActions();
         });
     }


### PR DESCRIPTION
## Proposed Fix for Issue #3

**Replication steps:**
- Install as a client-side mod to Fabric for Minecraft 26.1.2
- Enter a single-player world
- Exit world to main menu, and then enter a world again

**Expected:** World loads normally

**Actual:** World freezes loading beyond 1-2 surrounding chunks in any direction, and entire game freezes on attempt to exit world


## Cause
When a client exits a single player world to the main menu, the `ServerLifecycleEvents.SERVER_STOPPING` fires, and `Timer.INSTANCE` calls its `clearAllPendingActions` method, which clears pending actions.

However, since this server event fires before the server is completely shut down, other threads can still populate data into `Timer` after the clear has occurred. Because `Timer` is static, this leaked data carries over in memory to the next world session. On the second world load, these stale callbacks attempt to execute against invalid or null world references from the previous world session, causing the integrated server thread to freeze.

## Solution
Change the Timer's shutdown event's binding from `SERVER_STOPPING` to `SERVER_STOPPED`. This ensures that the `pendingActions` map is cleared

Closes #3